### PR TITLE
qmake prefix support and translations fix

### DIFF
--- a/krokonf.pro
+++ b/krokonf.pro
@@ -5,6 +5,12 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 CONFIG += c++11
 
+isEmpty(PREFIX) {
+ PREFIX = /usr/local
+}
+
+DEFINES += INSTALL_PREFIX=$$PREFIX
+
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
@@ -26,8 +32,13 @@ FORMS += \
 
 TRANSLATIONS = translations/krokonf_en.ts
 
+QM_FILES_INSTALL_PATH = $$PREFIX/share/krokonf/translations
+
+CONFIG+=lrelease
+
+
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/bin
+else: unix:!android: target.path = $$PREFIX/bin
 !isEmpty(target.path): INSTALLS += target
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,10 +4,6 @@
 #include <QApplication>
 #include <QTranslator>
 
-#ifndef INSTALL_PREFIX
-#define INSTALL_PREFIX "/usr/local"
-#endif
-
 #define xstr(s) str(s)
 #define str(s) #s
 
@@ -17,9 +13,7 @@ int main(int argc, char *argv[])
 	QApplication a(argc, argv);
 
 	QTranslator trans;
-	if (!trans.load(QLocale(), "krokonf", "_", xstr (INSTALL_PREFIX)"/share/krokonf/translations/")) {
-		trans.load(QLocale(), "krokonf", "_", ".");
-	}
+	trans.load(QLocale(), "krokonf", "_", xstr (INSTALL_PREFIX)"/share/krokonf/translations/");
 	a.installTranslator(&trans);
 	CrookConf c;
 	MainWindow w(&c);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,13 +4,22 @@
 #include <QApplication>
 #include <QTranslator>
 
+#ifndef INSTALL_PREFIX
+#define INSTALL_PREFIX "/usr/local"
+#endif
+
+#define xstr(s) str(s)
+#define str(s) #s
+
 // -----------------------------------------------------------------------
 int main(int argc, char *argv[])
 {
 	QApplication a(argc, argv);
 
 	QTranslator trans;
-	trans.load(QLocale(), "krokonf", "_", ".");
+	if (!trans.load(QLocale(), "krokonf", "_", xstr (INSTALL_PREFIX)"/share/krokonf/translations/")) {
+		trans.load(QLocale(), "krokonf", "_", ".");
+	}
 	a.installTranslator(&trans);
 	CrookConf c;
 	MainWindow w(&c);


### PR DESCRIPTION
Dodanie wsparcia dla zmiennej PREFIX obecnie ścieżki są zapisane na stałe co utrudnia tworzenie pakietów dla np. Fedory
Domyślnie PREFIX wskazuje na /usr/local, przykładowe wywołanie 
qmake-qt5 krokonf.pro PREFIX=/usr

Automatyczne tworzenie tłumaczeń (plików *.qm)
Pliki tłumaczeń są umieszczane w katalogu $PREFIX/share/krokonf/translations
Poprzedni program ładował tłumaczenia tylko z bieżącego katalogu, obecnie próbuje załadować z wyżej wymienionego katalogu.
